### PR TITLE
Create kics.yml

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -3,7 +3,7 @@ name: KICS
 
 permissions: read-all
 
-on: 
+on:
   push:
     branches: ["main"]
   pull_request:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,0 +1,39 @@
+---
+name: KICS
+
+permissions: read-all
+
+on: 
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+# Steps represent a sequence of tasks that will be executed as part of the job
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - name: Mkdir results-dir
+        # make sure results dir is created
+        run: mkdir -p results-dir
+      # Scan Iac with kics
+      - name: run kics Scan
+        uses: checkmarx/kics-github-action@v2.1.6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: "."
+          ignore_on_exit: results
+          enable_comments: true
+          output_path: results-dir
+          output_formats: "json,sarif" # Display the results in json format
+      - name: Show results
+        run: |
+          cat results-dir/results.sarif
+          cat results-dir/results.json
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results-dir/results.sarif

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -21,7 +21,7 @@ jobs:
         run: mkdir -p results-dir
       # Scan Iac with kics
       - name: run kics Scan
-        uses: checkmarx/kics-github-action@v2.1.6
+        uses: checkmarx/kics-github-action@09100f0152c975eb238c67030f9fd1418acb3666
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: "."
@@ -34,6 +34,6 @@ jobs:
           cat results-dir/results.sarif
           cat results-dir/results.json
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47
         with:
           sarif_file: results-dir/results.sarif


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate KICS (Keeping Infrastructure as Code Secure) scanning into the CI/CD pipeline. The workflow ensures that IaC (Infrastructure as Code) files are scanned for security vulnerabilities and compliance issues during pushes and pull requests to the `main` branch.

### New GitHub Actions Workflow:

* `.github/workflows/kics.yml`: Added a `KICS` workflow that:
  - Triggers on `push` and `pull_request` events targeting the `main` branch, as well as manually via `workflow_dispatch`.
  - Runs on `ubuntu-latest` and includes steps to:
    - Check out the repository.
    - Create a directory for results.
    - Perform a KICS scan using the `checkmarx/kics-github-action` to analyze IaC files, generate results in `json` and `sarif` formats, and enable commenting on pull requests.
    - Display the results in the workflow logs.
    - Upload the SARIF file for integration with GitHub's security features.