### PR TITLE
Update kics.yml

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -11,8 +11,11 @@ on:
   workflow_dispatch:
 # Steps represent a sequence of tasks that will be executed as part of the job
 jobs:
-  test:
+  kics:
     runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/kics.yml` to rename a job and adjust its permissions.

### Workflow configuration updates:
* Renamed the job from `test` to `kics` for better clarity and alignment with its purpose.
* Added `security-events: write` permission under the `permissions` section, which is required for all workflows.Fix kics permissions and rename job