### PR TITLE
Create hadolint.yml

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,12 +10,12 @@ name: Hadolint
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '30 1 * * 5'
+    - cron: "30 1 * * 5"
 
 permissions:
   contents: read

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,47 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# hadoint is a Dockerfile linter written in Haskell
+# that helps you build best practice Docker images.
+# More details at https://github.com/hadolint/hadolint
+
+name: Hadolint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '30 1 * * 5'
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Run hadolint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ./Dockerfile
+          format: sarif
+          output-file: hadolint-results.sarif
+          no-fail: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: hadolint-results.sarif
+          wait-for-processing: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate Hadolint, a Dockerfile linter, into the CI/CD pipeline. The workflow ensures Dockerfiles adhere to best practices by running automated linting on pushes, pull requests, and a scheduled weekly basis.

### New GitHub Actions Workflow:

* `.github/workflows/hadolint.yml`: Added a workflow named "Hadolint" to lint Dockerfiles using Hadolint. The workflow runs on pushes and pull requests to the `main` branch, as well as on a weekly schedule. It includes steps to:
  - Checkout the repository code.
  - Run Hadolint with SARIF output format and save the results to a file.
  - Upload the SARIF results to GitHub for analysis.