### PR TITLE
update public resolvers location

### DIFF
--- a/dnscrypt-proxy.toml
+++ b/dnscrypt-proxy.toml
@@ -21,7 +21,7 @@ forwarding_rules = "/etc/dnscrypt-proxy/forwarding-rules.txt"
 
 [sources]
   [sources.'public-resolvers']
-  url = 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md'
+  url = 'https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/public-resolvers.md'
   cache_file = '/var/cache/dnscrypt-proxy/public-resolvers.md'
   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
   refresh_delay = 72


### PR DESCRIPTION
This pull request updates the `dnscrypt-proxy.toml` configuration file to use a new URL for the public resolvers list.

* [`dnscrypt-proxy.toml`](diffhunk://#diff-b97b59dafd222f6b38f15984df7968e256eefe766f34278aa4750644266e595fL24-R24): Changed the `url` for `public-resolvers` to point to the updated location at `https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/public-resolvers.md`.