### PR TITLE
Use documented source list

### DIFF
--- a/dnscrypt-proxy.toml
+++ b/dnscrypt-proxy.toml
@@ -21,8 +21,6 @@ forwarding_rules = "/etc/dnscrypt-proxy/forwarding-rules.txt"
 
 [sources]
   [sources.'public-resolvers']
-  url = 'https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/public-resolvers.md'
-  cache_file = '/var/cache/dnscrypt-proxy/public-resolvers.md'
+  urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md']
   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
-  refresh_delay = 72
-  prefix = ''
+  cache_file = 'public-resolvers.md'


### PR DESCRIPTION
This pull request updates the `dnscrypt-proxy.toml` configuration file to enhance the flexibility and reliability of the DNS resolver sources by introducing multiple URLs for fetching resolver lists and simplifying caching settings.

DNS resolver source updates:

* [`dnscrypt-proxy.toml`](diffhunk://#diff-b97b59dafd222f6b38f15984df7968e256eefe766f34278aa4750644266e595fL24-R26): Replaced the single URL for fetching DNS resolver lists with multiple URLs to ensure redundancy and reliability.
* [`dnscrypt-proxy.toml`](diffhunk://#diff-b97b59dafd222f6b38f15984df7968e256eefe766f34278aa4750644266e595fL24-R26): Simplified the cache file path by removing the directory prefix, making it `public-resolvers.md`.