### PR TITLE
Bump dnscrypt-proxy to 2.1.14-r7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Update and install in a single RUN instruction to reduce layers
 # Pin specific versions for better reproducibility
 RUN apk add --no-cache \
-    dnscrypt-proxy=2.1.14-r5 \
+    dnscrypt-proxy=2.1.14-r7 \
     netcat-openbsd=1.234.1-r0
 
 # Create directory for custom configuration


### PR DESCRIPTION
## Summary
- Alpine 3.23 community now ships `dnscrypt-proxy` at `2.1.14-r7`, causing the pinned `r5` to fail the Docker build with `breaks: world[dnscrypt-proxy=2.1.14-r5]`.
- `netcat-openbsd` is still at `1.234.1-r0` per the 3.23-stable APKBUILD, so no change needed there.

## Test plan
- [ ] CI Docker build succeeds on linux/amd64 and linux/arm64.

https://claude.ai/code/session_01WNXh3zSPGg4wVjh3mLJjfV